### PR TITLE
fix: correct resource name in GeofenceService from 'geofence' to 'geo…

### DIFF
--- a/src/services/cache-initializer.ts
+++ b/src/services/cache-initializer.ts
@@ -14,16 +14,16 @@ const routeService = container.resolve(RouteService);
 const geofenceService$ = container.resolve(GeofenceService);
 
 export const cacheInitializer = (): Observable<unknown> => {
-	const routes$ = routeService.getAll();
+	// const routes$ = routeService.getAll();
 	const geofence$ = geofenceService$.getAllPaginated({});
 
 	return of(null).pipe(
-		concatMap(() => routes$),
-		tap(response => {
-			const responseData = handleAsArray(response);
+		// concatMap(() => routes$),
+		// tap(response => {
+		// 	const responseData = handleAsArray(response);
 
-			routeCache.updateAll([...responseData]);
-		}),
+		// 	routeCache.updateAll([...responseData]);
+		// }),
 		concatMap(() => geofence$),
 		tap((response: ApiResponse<GeofenceResponse>) => {
 			geofenceCacheInit(handleAsArray(response));

--- a/src/services/geofence/geofence.service.ts
+++ b/src/services/geofence/geofence.service.ts
@@ -8,7 +8,7 @@ export default class GeofenceService extends AbstractApiService<GeofenceResponse
 	constructor() {
 		super({
 			baseUrl: `${environment.BACKEND_URL}/trackingdb`,
-			resource: 'geofence',
+			resource: 'geofences',
 		});
 	}
 }


### PR DESCRIPTION
…fences'

refactor: comment out unused route handling in cacheInitializer