### PR TITLE
feat: implementar gestión de dispositivos

### DIFF
--- a/src/app/device/device-paths.ts
+++ b/src/app/device/device-paths.ts
@@ -1,0 +1,3 @@
+export const devicePaths = {
+	DEFAULT: '',
+} as const;

--- a/src/app/device/device.controller.ts
+++ b/src/app/device/device.controller.ts
@@ -1,0 +1,13 @@
+import { inject, injectable } from 'tsyringe';
+import DeviceCache from './cache/device-cache';
+import { StatusCodes } from 'http-status-codes';
+import { Request, Response } from 'express';
+
+@injectable()
+export default class DeviceController {
+	constructor(@inject(DeviceCache) private readonly deviceCache: DeviceCache) {}
+
+	public readonly getAllInCache = (req: Request, res: Response): void => {
+		res.status(StatusCodes.OK).json(this.deviceCache.getAll());
+	};
+}

--- a/src/app/device/device.routes.ts
+++ b/src/app/device/device.routes.ts
@@ -1,0 +1,13 @@
+import { Router } from 'express';
+import { devicePaths } from './device-paths';
+import { container } from 'tsyringe';
+import DeviceController from './device.controller';
+
+const { DEFAULT } = devicePaths;
+const router = Router();
+
+const { getAllInCache } = container.resolve(DeviceController);
+
+router.get(DEFAULT, getAllInCache);
+
+export default router;

--- a/src/app/device/device.swagger.ts
+++ b/src/app/device/device.swagger.ts
@@ -1,0 +1,34 @@
+import { LoadSwaggerDocsSchema } from '@docs/load-swagger-docs.schema';
+import SwaggerRegisterPath from '@docs/swagger/swagger-register-path';
+import ZodSwaggerGenerator from '@docs/swagger/zod-swagger-generator';
+import { container } from 'tsyringe';
+import { devicePaths } from './device-paths';
+import { array } from 'zod/v4';
+import { Device } from './entity/device';
+
+const { DEFAULT } = devicePaths;
+
+export const deviceSwagger = ({ path, tag }: LoadSwaggerDocsSchema): void => {
+	const zodSwaggerGenerator = container.resolve(ZodSwaggerGenerator);
+
+	SwaggerRegisterPath.builder()
+		.withRegister(zodSwaggerGenerator.getRegistry())
+		.withRequest({
+			method: 'get',
+			path: `${path}${DEFAULT}`,
+			summary: 'get all devices in cache',
+			tags: [tag],
+			request: {},
+			responses: {
+				200: {
+					description: '',
+					content: {
+						'application/json': {
+							schema: array(Device),
+						},
+					},
+				},
+			},
+		})
+		.register();
+};

--- a/src/docs/load-all-swagger-docs.ts
+++ b/src/docs/load-all-swagger-docs.ts
@@ -3,6 +3,7 @@ import { container } from 'tsyringe';
 import ZodSwaggerGenerator from './swagger/zod-swagger-generator';
 import { groupSwagger } from '@app/group/group.swagger';
 import { geofenceSwagger } from '@app/geofence/geofence.swagger';
+import { deviceSwagger } from '@app/device/device.swagger';
 
 export const loadAllSwaggerDocs = (): void => {
 	const BASE_PATH: string = '/api/v1';
@@ -15,10 +16,11 @@ export const loadAllSwaggerDocs = (): void => {
 		},
 		{ name: 'GEOFENCE', description: 'management of geofences' },
 		{ name: 'GROUP', description: 'management of group vehicles' },
+		{ name: 'DEVICE', description: 'management of devices' },
 	];
 
 	testSwagger({
-		path: `${BASE_PATH}/test`,
+		path: `${BASE_PATH}/tests`,
 		tag: 'TEST',
 	});
 
@@ -30,6 +32,11 @@ export const loadAllSwaggerDocs = (): void => {
 	groupSwagger({
 		path: `${BASE_PATH}/groups`,
 		tag: 'GROUP',
+	});
+
+	deviceSwagger({
+		path: `${BASE_PATH}/devices`,
+		tag: 'DEVICE',
 	});
 
 	zodSwaggerGenerator.setTags(TAGS_CONFIG);

--- a/src/routes/v1/index.routes.ts
+++ b/src/routes/v1/index.routes.ts
@@ -2,11 +2,13 @@ import { Router } from 'express';
 import testRouter from '@app/test-app/test.routes';
 import geofenceRouter from '@app/geofence/geofence.routes';
 import groupRouter from '@app/group/group.routes';
+import deviceRouter from '@app/device/device.routes';
 
 const router = Router();
 
 router.use('/groups', groupRouter);
 router.use('/geofences', geofenceRouter);
-router.use('/test', testRouter);
+router.use('/devices', deviceRouter);
+router.use('/tests', testRouter);
 
 export default router;

--- a/test/unit/docs/load-all-swagger-docs.test.ts
+++ b/test/unit/docs/load-all-swagger-docs.test.ts
@@ -12,12 +12,17 @@ vi.mock('@app/group/group.swagger', () => ({
 	groupSwagger: vi.fn(),
 }));
 
+vi.mock('@app/device/device.swagger', () => ({
+	deviceSwagger: vi.fn(),
+}));
+
 import { testSwagger } from '@app/test-app/test.swagger';
 import { loadAllSwaggerDocs } from '@src/docs/load-all-swagger-docs';
 import ZodSwaggerGenerator from '@src/docs/swagger/zod-swagger-generator';
 import { container } from 'tsyringe';
 import { groupSwagger } from '@app/group/group.swagger';
 import { geofenceSwagger } from '@app/geofence/geofence.swagger';
+import { deviceSwagger } from '@app/device/device.swagger';
 
 describe('load all swagger docs test', () => {
 	const BASE_PATH: string = '/api/v1';
@@ -41,7 +46,7 @@ describe('load all swagger docs test', () => {
 		loadAllSwaggerDocs();
 
 		expect(testSwagger).toHaveBeenCalledWith(
-			expect.objectContaining({ path: `${BASE_PATH}/test`, tag: 'TEST' }),
+			expect.objectContaining({ path: `${BASE_PATH}/tests`, tag: 'TEST' }),
 		);
 
 		expect(geofenceSwagger).toHaveBeenCalledWith(
@@ -55,6 +60,10 @@ describe('load all swagger docs test', () => {
 			expect.objectContaining({ path: `${BASE_PATH}/groups`, tag: 'GROUP' }),
 		);
 
+		expect(deviceSwagger).toHaveBeenCalledWith(
+			expect.objectContaining({ path: `${BASE_PATH}/devices`, tag: 'DEVICE' }),
+		);
+
 		expect(mockTags).toHaveBeenCalledWith([
 			expect.objectContaining({
 				name: 'TEST',
@@ -66,6 +75,10 @@ describe('load all swagger docs test', () => {
 			}),
 			expect.objectContaining({
 				name: 'GROUP',
+				description: expect.any(String),
+			}),
+			expect.objectContaining({
+				name: 'DEVICE',
 				description: expect.any(String),
 			}),
 		]);


### PR DESCRIPTION
- Se añadieron nuevos archivos para la gestión de dispositivos, incluyendo el controlador, rutas y esquemas Swagger.
- Se creó un sistema de rutas para obtener todos los dispositivos en caché.
- Se registró la documentación Swagger para la gestión de dispositivos.
- Se realizaron ajustes en la carga de documentación Swagger para incluir la nueva ruta de dispositivos.